### PR TITLE
Target Python 3.11 in Pipenv configuration

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,4 +11,4 @@ python-dotenv = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.13"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a09288f10b207bfbe868ee65e5a5487e0d37cb3ac4c7888d72d726bbbc34f652"
+            "sha256": "656bfafa955f9c51df7ce023f1b84bae1e1bdb3407484d70944fce55c4d77d3f"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.13"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Using the JIRA api to achieve the same results. Decided to also use TDD and lear
 
 ## Set up
 
+> **Python requirement:** This project targets Python 3.11. Make sure that version is available in your environment before installing dependencies.
+
 ### Add to AWS as a Lamda
 
 ### Add secrets / create JIRA API token not linked to my person account

--- a/set-up.bat
+++ b/set-up.bat
@@ -1,7 +1,8 @@
 ::Set up commands for Windows
 
-::Run pipenv shell to activate the environment depenancies
+::Ensure Python 3.11 is installed and on PATH before continuing
 
+::Run pipenv shell to activate the environment dependencies
 pip install pipenv
 
 pipenv shell

--- a/set-up.sh
+++ b/set-up.sh
@@ -2,9 +2,12 @@
 
 #Set up commands for Linux / Coder Workspace
 
+#Ensure Python 3.11 is installed before setting up Pipenv
+sudo apt install -y python3.11 python3.11-venv
+
 sudo apt update
 
-sudo apt install -y python3 python3-pip python3-pipenv
+sudo apt install -y python3-pip python3-pipenv
 
 #Run pipenv shell to activate the environment depenancies
 


### PR DESCRIPTION
## Summary
- update the Pipenv configuration to require Python 3.11
- document the Python 3.11 requirement across the setup guides
- adjust setup scripts to ensure Python 3.11 is installed before activating Pipenv

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dccc4cb238834697790307763dafc1